### PR TITLE
Variable Climbing sound 

### DIFF
--- a/libraries/beeper/beeper.cpp
+++ b/libraries/beeper/beeper.cpp
@@ -157,6 +157,7 @@ void beeper::setVelocity(double velocity) {
   if( (beepTypeChange && !bst_isset(CLIMBING_ALARM) && !bst_isset(SINKING_ALARM) ) ||
       (startAlarm) ) {
     beepStartTime = millis();
+	beepFreqUpdatePosition = beepStartTime;
     beepPaternBasePosition = 0.0;
     beepPaternPosition = 0.0;
     bst_set(BEEP_NEW_FREQ); //force changing freq
@@ -217,6 +218,10 @@ void beeper::setBeepPaternPosition(double velocity) {
     if( currentLength + beepPaternBasePosition > beepPaternPosition ) {
       beepPaternPosition = currentLength + beepPaternBasePosition;
     }
+    if (currentTime > beepFreqUpdatePosition + CLIMBING_BEEP_FREQ_UPDATE && CLIMBING_BEEP_FREQ_UPDATE > 0) {
+      bst_set(BEEP_NEW_FREQ);
+      beepFreqUpdatePosition = currentTime;	
+	}	
   } else {
     beepPaternPosition = currentLength;
   }

--- a/libraries/beeper/beeper.h
+++ b/libraries/beeper/beeper.h
@@ -46,6 +46,7 @@
 /* climbing beep sound freq computation : BEEP_FREQ_COEFF * velocity + BEEP_BASE_FREQ */
 #define CLIMBING_BEEP_BASE_FREQ 386.0
 #define CLIMBING_BEEP_FREQ_COEFF 141.0
+#define CLIMBING_BEEP_FREQ_UPDATE 1  // update climbing beep frequency(pitch) after X milliseconds. 0 = monotonous beep, do not update frequency while beep is playing. 1 = pitch changes smoothly every 1ms. more than 1 = pitch changed in steps every X milliseconds.
 
 /* climbing beep velocity filter */
 /* filteredVelocity = beepVelocity * BEEP_VELOCITY_FILTER_COEFF + BEEP_VELOCITY_FILTER_BASE */
@@ -141,6 +142,7 @@ class beeper {
   double beepClimbingThreshold;
   uint8_t volume;
   unsigned long beepStartTime;
+  unsigned long beepFreqUpdatePosition;
   double beepVelocity;
   double beepFreq;
   double beepPaternBasePosition;


### PR DESCRIPTION
Hi Baptiste, I see that in [aa9d997822746be28f4f0cfbc94a897504288c03](https://github.com/prunkdump/arduino-variometer/commit/aa9d997822746be28f4f0cfbc94a897504288c03) You implemented the variable sinking beep, but not the variable climbing beep. I wonder if you tested it and were just unhappy with the change, or for any other reason?
My patch did not break or changed the previous behaviour, but it added functionality - being able to set a climbing beep that is varying in frequency during a beep, or keeping the monotonous beep. I think many (if not most?) varios use a varying frequency beep. and I find it a lot more informative as I don't need to wait for the next beep to understand the variance in climb rate since the current beep started.
Do you think otherwise?
I made a branch that merges with no errors for you to test. please note that for your default behavior you need to change the `#define CLIMBING_BEEP_FREQ_UPDATE`  back to 0.

`#define CLIMBING_BEEP_FREQ_UPDATE 1  // update climbing beep frequency(pitch) after X milliseconds. 0 = monotonous beep, do not update frequency while beep is playing. 1 = pitch changes smoothly every 1ms. more than 1 = pitch changed in steps every X milliseconds.`