### PR TITLE
Low voltage alert

### DIFF
--- a/libraries/VarioSettings/VarioSettings.h
+++ b/libraries/VarioSettings/VarioSettings.h
@@ -66,6 +66,10 @@
 //#define VARIOMETER_ENABLE_NEAR_CLIMBING_ALARM
 //#define VARIOMETER_ENABLE_NEAR_CLIMBING_BEEP
 
+// Reminder beeps on low battery
+#define HAVE_LOW_BATTERY_BEEP
+#define BATTERY_BEEPS_INTERVAL 2000 // 30000 for prod
+#define LOW_BATT_BEEP_THRESOLD 3350 // low voltage thresold in mV
 
 /*******************/
 /* Screen behavior */
@@ -147,7 +151,8 @@
 #define HAVE_GPS
 #define HAVE_SDCARD
 #define HAVE_BLUETOOTH
-#define HAVE_VOLTAGE_DIVISOR
+//#define HAVE_VOLTAGE_DIVISOR
+#define HAVE_INTERNAL_VOLTMETER // For 5V chips powered straight from battery
 
 /* ms5611 parameters */
 /* You can set the calibration coefficients if known */

--- a/libraries/VarioSettings/VarioSettings.h
+++ b/libraries/VarioSettings/VarioSettings.h
@@ -68,7 +68,7 @@
 
 // Reminder beeps on low battery
 #define HAVE_LOW_BATTERY_BEEP
-#define BATTERY_BEEPS_INTERVAL 2000 // 30000 for prod
+#define BATTERY_BEEPS_INTERVAL 30000 // 30000 for prod
 #define LOW_BATT_BEEP_THRESOLD 3350 // low voltage thresold in mV
 
 /*******************/

--- a/variometer/variometer.ino
+++ b/variometer/variometer.ino
@@ -279,6 +279,13 @@ void beeperTapCallback(unsigned char direction, unsigned char count) {
 #endif //defined(HAVE_ACCELEROMETER) && defined(HAVE_SPEAKER) 
 
 
+/*********************/
+/* Low voltage beep  */
+/*********************/
+#ifdef HAVE_LOW_BATTERY_BEEP
+unsigned long batteryBeeps_lastrun;
+#endi
+
 /*-----------------*/
 /*      SETUP      */
 /*-----------------*/
@@ -639,9 +646,63 @@ void loop() {
   varioScreen.displayStep();
 
 #endif //HAVE_SCREEN 
+
+#ifdef HAVE_LOW_BATTERY_BEEP
+  makeBatteryBeeps();
+#endif
+ 
 }
 
+#ifdef HAVE_LOW_BATTERY_BEEP
+void makeBatteryBeeps(){
+  if ( millis() - batteryBeeps_lastrun > BATTERY_BEEPS_INTERVAL ){
+    batteryBeeps_lastrun = millis(); 
+    #ifdef HAVE_VOLTAGE_DIVISOR
+    // To be implemented
+    #endif // HAVE_VOLTAGE_DIVISOR
+    #ifdef HAVE_INTERNAL_VOLTMETER
+    if (readVcc() < LOW_BATT_BEEP_THRESOLD)
+    {
+      for (char i = 0; i < 5; i++)
+      {
+        toneAC(1000,10);
+        delay(50);
+        toneAC(0,0);
+        delay(50);
+      }
+      
+    }
+    #endif //HAVE_INTERNAL_VOLTMETER
 
+  }
+}
+
+long readVcc() {
+  // Read 1.1V reference against AVcc
+  // set the reference to Vcc and the measurement to the internal 1.1V reference
+  #if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+    ADMUX = _BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1);
+  #elif defined (__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+    ADMUX = _BV(MUX5) | _BV(MUX0);
+  #elif defined (__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+    ADMUX = _BV(MUX3) | _BV(MUX2);
+  #else
+    ADMUX = _BV(REFS0) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1);
+  #endif  
+
+  delay(2); // Wait for Vref to settle
+  ADCSRA |= _BV(ADSC); // Start conversion
+  while (bit_is_set(ADCSRA,ADSC)); // measuring
+
+  uint8_t low  = ADCL; // must read ADCL first - it then locks ADCH  
+  uint8_t high = ADCH; // unlocks both
+
+  long result = (high<<8) | low;
+
+  result = 1125300L / result; // Calculate Vcc (in mV); 1125300 = 1.1*1023*1000
+  return result; // Vcc in millivolts
+}
+#endif // HAVE_LOW_BATTERY_BEEP
 
 #if defined(HAVE_SDCARD) && defined(HAVE_GPS)
 void createSDCardTrackFile(void) {


### PR DESCRIPTION
### Ajouts : 
- Alerte sonore lorsque la tension de batterie est basse
- Mesure de la tension de batterie au regard de la référence interne pour les puces 5V alimentées directement sur la tension de lipo

### Bénéfices : 
- Alerte sonore de batterie faible pour les appareils sans écran
- Mesure de tension simplifiée sur les appareils 5V

### Problèmes connus : 
- L'alerte sonore n'est pas implémentée pour la mesure avec VOLTAGE_DIVISOR (Fixme!)